### PR TITLE
Feature: Product Card Components on Home Page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -44,3 +44,8 @@
   height: 200px;
   width: 100%;
 }
+
+.product-card-hover:hover {
+  cursor: pointer;
+  box-shadow: 0 0.3rem 1.525rem -0.375rem rgb(0 0 0 / 10%);
+}

--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,11 @@
     transform: rotate(360deg);
   }
 }
+
+.sh-bg-img {
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+  height: 200px;
+  width: 100%;
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Link, useHistory } from 'react-router-dom';
+
+interface CardProps {
+  product: Product;
+}
+
+const ProductCard: React.FC<CardProps> = ({ product }) => {
+  const history = useHistory();
+  return (
+    <div className='card h-100 product-card-hover d-flex flex-column justify-content-between'>
+      <span
+        className=''
+        onClick={() => history.push(`/products/${product.id}`)}>
+        {/* Image on Top */}
+        <div className='sh-card-img'>
+          <div
+            className='sh-bg-img'
+            style={{ backgroundImage: `url(${product.image})` }}></div>
+        </div>
+
+        {/* Card Body */}
+        <div className='card-body'>
+          <h5 className='card-title'>
+            <Link to={`/products/${product.id}`}>{product.title}</Link>
+          </h5>
+          <div className='d-flex justify-content-between align-items-center'>
+            <strong>${product.price}</strong>
+            <span className='badge badge-warning'>{product.category}</span>
+          </div>
+        </div>
+      </span>
+
+      {/* Add to Cart Button  */}
+      <div className='card-footer'>
+        <button className='btn btn-block btn-primary'>Add To Cart</button>
+      </div>
+    </div>
+  );
+};
+
+export default ProductCard;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useContext } from 'react';
-import { Link } from 'react-router-dom';
+import ProductCard from '../components/ProductCard';
 import { GlobalContext } from '../context/GlobalContext';
 import '../App.css';
 
@@ -22,34 +22,7 @@ const HomePage = () => {
         {products.map((product, i) => {
           return (
             <div className='col-sm-12 col-md-3 mb-3' key={i}>
-              <div className='card h-100'>
-                {/* Image on Top */}
-                <div className='sh-card-img'>
-                  <div
-                    className='sh-bg-img'
-                    style={{ backgroundImage: `url(${product.image})` }}></div>
-                </div>
-
-                {/* Card Body */}
-                <div className='card-body'>
-                  <h5 className='card-title'>
-                    <Link to={`/products/${product.id}`}>{product.title}</Link>
-                  </h5>
-                  <div className='d-flex justify-content-between align-items-center'>
-                    <strong>${product.price}</strong>
-                    <span className='badge badge-warning'>
-                      {product.category}
-                    </span>
-                  </div>
-                </div>
-
-                {/* Add to Cart Button  */}
-                <div className='card-footer'>
-                  <button className='btn btn-block btn-primary'>
-                    Add To Cart
-                  </button>
-                </div>
-              </div>
+              <ProductCard product={product} />
             </div>
           );
         })}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import { GlobalContext } from '../context/GlobalContext';
+import '../App.css';
 
 const HomePage = () => {
   const { products, getProducts } = useContext(GlobalContext);
@@ -17,17 +19,40 @@ const HomePage = () => {
         </div>
       </div>
       <div className='row'>
-        <div className='col-md-8 offset-md-2'>
-          <ul className='list-group'>
-            {products.map((product, i) => {
-              return (
-                <li className='list-group-item' key={i}>
-                  {product.title}
-                </li>
-              );
-            })}
-          </ul>
-        </div>
+        {products.map((product, i) => {
+          return (
+            <div className='col-sm-12 col-md-3 mb-3' key={i}>
+              <div className='card h-100'>
+                {/* Image on Top */}
+                <div className='sh-card-img'>
+                  <div
+                    className='sh-bg-img'
+                    style={{ backgroundImage: `url(${product.image})` }}></div>
+                </div>
+
+                {/* Card Body */}
+                <div className='card-body'>
+                  <h5 className='card-title'>
+                    <Link to={`/products/${product.id}`}>{product.title}</Link>
+                  </h5>
+                  <div className='d-flex justify-content-between align-items-center'>
+                    <strong>${product.price}</strong>
+                    <span className='badge badge-warning'>
+                      {product.category}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Add to Cart Button  */}
+                <div className='card-footer'>
+                  <button className='btn btn-block btn-primary'>
+                    Add To Cart
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/routers/AppRoutes.tsx
+++ b/src/routers/AppRoutes.tsx
@@ -11,7 +11,7 @@ const AppRoutes = () => {
   return (
     <div>
       <Navbar />
-      <div className='container'>
+      <div className='container-fluid'>
         <Switch>
           <Route path='/' exact component={HomePage} />
           <Route path='/products/:productId' component={ProductPage} />


### PR DESCRIPTION
**When you open your pull requests, remove the lines that start and end with underscores (\_)**

## Changes

1. Render Product item info on home page
2. Product Card Component for data rendering

## Purpose

Add a product card for items on home page. Clickable functionality to navigate to single card page

## Screenshots

![Screen Shot 2021-05-03 at 2 07 13 PM](https://user-images.githubusercontent.com/11038686/116933778-e1a7df80-ac18-11eb-8e57-b150738c50b6.png)


### Closes #16 
