### PR TITLE
FIX: Decimal display in product cards

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, {useContext}  from 'react';
 import { Link, useHistory } from 'react-router-dom';
+import { GlobalContext } from '../context/GlobalContext';
+import {setTypeColor} from '../services';
 
 interface CardProps {
   product: Product;
 }
 
 const ProductCard: React.FC<CardProps> = ({ product }) => {
+  const {RoundDecimal} = useContext(GlobalContext);
+
   const history = useHistory();
   return (
     <div className='card h-100 product-card-hover d-flex flex-column justify-content-between'>
@@ -25,8 +29,8 @@ const ProductCard: React.FC<CardProps> = ({ product }) => {
             <Link to={`/products/${product.id}`}>{product.title}</Link>
           </h5>
           <div className='d-flex justify-content-between align-items-center'>
-            <strong>${product.price}</strong>
-            <span className='badge badge-warning'>{product.category}</span>
+            <strong>${RoundDecimal(product.price)}</strong>
+            <span className='badge text-white' style={{backgroundColor:setTypeColor(product.category)}}> {product.category} </span>
           </div>
         </div>
       </span>

--- a/src/components/SingleProductCard.tsx
+++ b/src/components/SingleProductCard.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+interface CardProps {
+  product: Product;
+}
+
+const SingleProductCard: React.FC<CardProps> = ({ product }) => {
+  return (
+    <div className='row'>
+    <div className='col-sm-12 col-md-8 offset-md-2'>
+      <div className='card'>
+        <div className='row'>
+          {/* Product Img */}
+          <div className='col-sm-12 col-md-4'>
+            <div className='prod-img-container p-3'>
+              <div
+                className='prod-img'
+                style={{ backgroundImage: `url(${product.image})` }}></div>
+            </div>
+          </div>
+          {/* product details */}
+          <div className='col-sm-12 col-md-8'>
+            <div className='card-body d-flex flex-column justify-content-between h-100'>
+              {/* product title */}
+              <h3 className='card-title'>
+                {product.title}
+                <div className=''>
+                  <small className='text-info'>${product.price}</small>
+                </div>
+              </h3>
+              {/* product details */}
+              <div className='card-details'>
+                <h4>Description</h4>
+                <p>{product.description}</p>
+                <div>
+                  <span className='badge badge-warning'>
+                    {product.category}
+                  </span>
+                </div>
+              </div>
+              {/* product add to cart */}
+              <div className='card-cart'>
+                <div className='row'>
+                  <div className='col-2'>
+                    <div className='form-group'>
+                      <select className='form-control'>
+                        <option value='1'>1</option>
+                        <option value='2'>2</option>
+                        <option value='3'>3</option>
+                      </select>
+                    </div>
+                  </div>
+
+                  <div className='col-10'>
+                    <button className='btn btn-block btn-danger'>
+                      Add To Cart
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  );
+};
+
+export default SingleProductCard;

--- a/src/components/SingleProductCard.tsx
+++ b/src/components/SingleProductCard.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, {useContext}  from 'react';
+import { GlobalContext } from '../context/GlobalContext';
+import {setTypeColor} from '../services';
 
 interface CardProps {
   product: Product;
 }
 
+
 const SingleProductCard: React.FC<CardProps> = ({ product }) => {
-  return (
+    const {RoundDecimal} = useContext(GlobalContext);
+
+    return (
     <div className='row'>
     <div className='col-sm-12 col-md-8 offset-md-2'>
       <div className='card'>
@@ -25,7 +30,7 @@ const SingleProductCard: React.FC<CardProps> = ({ product }) => {
               <h3 className='card-title'>
                 {product.title}
                 <div className=''>
-                  <small className='text-info'>${product.price}</small>
+                  <small className='text-info'>${RoundDecimal(product.price)}</small>
                 </div>
               </h3>
               {/* product details */}
@@ -33,7 +38,7 @@ const SingleProductCard: React.FC<CardProps> = ({ product }) => {
                 <h4>Description</h4>
                 <p>{product.description}</p>
                 <div>
-                  <span className='badge badge-warning'>
+                  <span className='badge text-white' style={{backgroundColor:setTypeColor(product.category)}}>
                     {product.category}
                   </span>
                 </div>

--- a/src/context/GlobalContext.tsx
+++ b/src/context/GlobalContext.tsx
@@ -8,6 +8,7 @@ const initialState = {
   product: undefined,
   getProducts: () => {},
   getSingleProduct: () => {},
+  RoundDecimal:()=>{},
 };
 
 // Create our global reducer
@@ -65,6 +66,13 @@ export const GlobalProvider: React.FC = ({ children }) => {
     }
   };
 
+  // Functiion to round decimals
+  const RoundDecimal = (price:string)=>{
+    let num = +price;
+    let rounded = num.toFixed(2);
+    return rounded;
+  }
+
   return (
     <GlobalContext.Provider
       value={{
@@ -73,6 +81,7 @@ export const GlobalProvider: React.FC = ({ children }) => {
         product: state.product,
         getProducts,
         getSingleProduct,
+        RoundDecimal,
       }}>
       {children} {/* <AppRouter/> */}
     </GlobalContext.Provider>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,7 +4,7 @@ import { GlobalContext } from '../context/GlobalContext';
 import '../App.css';
 
 const HomePage = () => {
-  const { products, getProducts } = useContext(GlobalContext);
+  const { products, getProducts} = useContext(GlobalContext);
 
   useEffect(() => {
     getProducts();

--- a/src/pages/ProductPage.tsx
+++ b/src/pages/ProductPage.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import SingleProductCard from '../components/SingleProductCard';
 import { GlobalContext } from '../context/GlobalContext';
 
 const ProductPage = () => {
@@ -37,66 +38,8 @@ const ProductPage = () => {
           </div>
         </div>
       </div>
-
       {/* Product Card */}
-      <div className='row'>
-        <div className='col-sm-12 col-md-8 offset-md-2'>
-          <div className='card'>
-            <div className='row'>
-              {/* Product Img */}
-              <div className='col-sm-12 col-md-4'>
-                <div className='prod-img-container p-3'>
-                  <div
-                    className='prod-img'
-                    style={{ backgroundImage: `url(${product.image})` }}></div>
-                </div>
-              </div>
-              {/* product details */}
-              <div className='col-sm-12 col-md-8'>
-                <div className='card-body d-flex flex-column justify-content-between h-100'>
-                  {/* product title */}
-                  <h3 className='card-title'>
-                    {product.title}
-                    <div className=''>
-                      <small className='text-info'>${product.price}</small>
-                    </div>
-                  </h3>
-                  {/* product details */}
-                  <div className='card-details'>
-                    <h4>Description</h4>
-                    <p>{product.description}</p>
-                    <div>
-                      <span className='badge badge-warning'>
-                        {product.category}
-                      </span>
-                    </div>
-                  </div>
-                  {/* product add to cart */}
-                  <div className='card-cart'>
-                    <div className='row'>
-                      <div className='col-2'>
-                        <div className='form-group'>
-                          <select className='form-control'>
-                            <option value='1'>1</option>
-                            <option value='2'>2</option>
-                            <option value='3'>3</option>
-                          </select>
-                        </div>
-                      </div>
-
-                      <div className='col-10'>
-                        <button className='btn btn-block btn-danger'>
-                          Add To Cart
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <SingleProductCard product={product}/>
     </div>
   );
 };

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,0 +1,21 @@
+enum TypeColor {
+    electronics = '#FFC107',
+    jewelery = '#007BFF',
+    mensClothing = '#DC3545',
+    womensClothing = '#17A2B8',
+}
+
+export const setTypeColor = (type: string): string => {
+    switch (type) {
+        case 'electronics':
+            return TypeColor.electronics;
+        case 'jewelery':
+            return TypeColor.jewelery;
+        case "men's clothing":
+            return TypeColor.mensClothing;
+        case "women's clothing":
+            return TypeColor.womensClothing;
+        default:
+            return'#333';
+    }
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -26,3 +26,5 @@ type InitialStateType = {
     getProducts: () => void;
     getSingleProduct: (productId:number) => void;
 };
+
+//test

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -26,5 +26,3 @@ type InitialStateType = {
     getProducts: () => void;
     getSingleProduct: (productId:number) => void;
 };
-
-//test

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -25,5 +25,6 @@ type InitialStateType = {
     product: Product | undefined;
     getProducts: () => void;
     getSingleProduct: (productId:number) => void;
+    RoundDecimal:(price:string)=>void;
 };
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -26,3 +26,4 @@ type InitialStateType = {
     getProducts: () => void;
     getSingleProduct: (productId:number) => void;
 };
+


### PR DESCRIPTION
## Changes

1. Added function in GlobalContext
2. Updated InitialStateType
3. Pushed GlobalContext to both card components
4. Applied the new function in both card components 

## Purpose
This is to force the price to display values up to the second decimal. 


## Screenshots
![image](https://user-images.githubusercontent.com/60980399/117081774-71bb5700-acf5-11eb-9858-51b98bb2b129.png)
![image](https://user-images.githubusercontent.com/60980399/117081804-85ff5400-acf5-11eb-9100-5d70963154e6.png)


### Refs Alex's issue #21
