### PR TITLE
bug: Display correct tag prices

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -3,9 +3,10 @@ import { Link, useHistory } from 'react-router-dom';
 
 interface CardProps {
   product: Product;
+  roundDecimalsValues: (priceTagNumber:number) =>void;
 }
 
-const ProductCard: React.FC<CardProps> = ({ product }) => {
+const ProductCard: React.FC<CardProps> = ({ product, roundDecimalsValues }) => {
   const history = useHistory();
   return (
     <div className='card h-100 product-card-hover d-flex flex-column justify-content-between'>
@@ -25,7 +26,7 @@ const ProductCard: React.FC<CardProps> = ({ product }) => {
             <Link to={`/products/${product.id}`}>{product.title}</Link>
           </h5>
           <div className='d-flex justify-content-between align-items-center'>
-            <strong>${product.price}</strong>
+            <strong>${roundDecimalsValues(+product.price)}</strong>
             <span className='badge badge-warning'>{product.category}</span>
           </div>
         </div>

--- a/src/components/SingleProductCard.tsx
+++ b/src/components/SingleProductCard.tsx
@@ -2,8 +2,10 @@ import {Link} from "react-router-dom";
 
 interface SingleCardProps {
     product: Product;
+    roundDecimalsValues: (priceTagNumber:number) =>void;
+
   }
-const SingleProductCard: React.FC<SingleCardProps>= ({product}) =>{
+const SingleProductCard: React.FC<SingleCardProps>= ({product, roundDecimalsValues}) =>{
     return (
         <div id='product'>
       {/* Breadcrumb */}
@@ -43,7 +45,7 @@ const SingleProductCard: React.FC<SingleCardProps>= ({product}) =>{
                   <h3 className='card-title'>
                     {product.title}
                     <div className=''>
-                      <small className='text-info'>${product.price}</small>
+                      <small className='text-info'>${roundDecimalsValues(+product.price)}</small>
                     </div>
                   </h3>
                   {/* product details */}

--- a/src/components/SingleProductCard.tsx
+++ b/src/components/SingleProductCard.tsx
@@ -1,0 +1,89 @@
+import {Link} from "react-router-dom";
+
+interface SingleCardProps {
+    product: Product;
+  }
+const SingleProductCard: React.FC<SingleCardProps>= ({product}) =>{
+    return (
+        <div id='product'>
+      {/* Breadcrumb */}
+      <div className='row my-3'>
+        <div className='col'>
+          <div className='page-breadcrumb'>
+            <h4>
+              <span>
+                <Link to='/'>Home</Link>
+              </span>
+              {' > '}
+              <span>
+                <Link to={`/products/${product.id}`}>{product.title}</Link>
+              </span>
+            </h4>
+          </div>
+        </div>
+      </div>
+
+      {/* Product Card */}
+      <div className='row'>
+        <div className='col-sm-12 col-md-8 offset-md-2'>
+          <div className='card'>
+            <div className='row'>
+              {/* Product Img */}
+              <div className='col-sm-12 col-md-4'>
+                <div className='prod-img-container p-3'>
+                  <div
+                    className='prod-img'
+                    style={{ backgroundImage: `url(${product.image})` }}></div>
+                </div>
+              </div>
+              {/* product details */}
+              <div className='col-sm-12 col-md-8'>
+                <div className='card-body d-flex flex-column justify-content-between h-100'>
+                  {/* product title */}
+                  <h3 className='card-title'>
+                    {product.title}
+                    <div className=''>
+                      <small className='text-info'>${product.price}</small>
+                    </div>
+                  </h3>
+                  {/* product details */}
+                  <div className='card-details'>
+                    <h4>Description</h4>
+                    <p>{product.description}</p>
+                    <div>
+                      <span className='badge badge-warning'>
+                        {product.category}
+                      </span>
+                    </div>
+                  </div>
+                  {/* product add to cart */}
+                  <div className='card-cart'>
+                    <div className='row'>
+                      <div className='col-2'>
+                        <div className='form-group'>
+                          <select className='form-control'>
+                            <option value='1'>1</option>
+                            <option value='2'>2</option>
+                            <option value='3'>3</option>
+                          </select>
+                        </div>
+                      </div>
+
+                      <div className='col-10'>
+                        <button className='btn btn-block btn-danger'>
+                          Add To Cart
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    )
+}
+
+export default SingleProductCard; 

--- a/src/context/GlobalContext.tsx
+++ b/src/context/GlobalContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useState, useReducer } from 'react';
+import React, { createContext,
+   useReducer } from 'react';
 import instance from '../api/apiConfig';
 
 // Initialize a default state for our app
@@ -8,7 +9,7 @@ const initialState = {
   product: undefined,
   getProducts: () => {},
   getSingleProduct: () => {},
-  addDecimalValues: () => {},
+  roundDecimalsValues: () => {},
 };
 
 // Create our global reducer
@@ -66,9 +67,13 @@ export const GlobalProvider: React.FC = ({ children }) => {
     }
   };
 
-  const addDecimalValues = (priceTagNumber: number) =>{
-      
-  }
+  const roundDecimalsValues = (priceTagNumber: number) =>{
+  const roundDecimalValue = priceTagNumber.toFixed(2);
+
+  return roundDecimalValue
+
+}
+
 
   return (
     <GlobalContext.Provider
@@ -78,7 +83,7 @@ export const GlobalProvider: React.FC = ({ children }) => {
         product: state.product,
         getProducts,
         getSingleProduct,
-        addDecimalValues
+        roundDecimalsValues
       }}>
       {children} {/* <AppRouter/> */}
     </GlobalContext.Provider>

--- a/src/context/GlobalContext.tsx
+++ b/src/context/GlobalContext.tsx
@@ -8,6 +8,7 @@ const initialState = {
   product: undefined,
   getProducts: () => {},
   getSingleProduct: () => {},
+  addDecimalValues: () => {},
 };
 
 // Create our global reducer
@@ -65,6 +66,10 @@ export const GlobalProvider: React.FC = ({ children }) => {
     }
   };
 
+  const addDecimalValues = (priceTagNumber: number) =>{
+      
+  }
+
   return (
     <GlobalContext.Provider
       value={{
@@ -73,6 +78,7 @@ export const GlobalProvider: React.FC = ({ children }) => {
         product: state.product,
         getProducts,
         getSingleProduct,
+        addDecimalValues
       }}>
       {children} {/* <AppRouter/> */}
     </GlobalContext.Provider>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,7 +4,7 @@ import { GlobalContext } from '../context/GlobalContext';
 import '../App.css';
 
 const HomePage = () => {
-  const { products, getProducts } = useContext(GlobalContext);
+  const { products, getProducts,roundDecimalsValues} = useContext(GlobalContext);
 
   useEffect(() => {
     getProducts();
@@ -22,7 +22,7 @@ const HomePage = () => {
         {products.map((product, i) => {
           return (
             <div className='col-sm-12 col-md-3 mb-3' key={i}>
-              <ProductCard product={product} />
+              <ProductCard roundDecimalsValues ={roundDecimalsValues} product={product} />
             </div>
           );
         })}

--- a/src/pages/ProductPage.tsx
+++ b/src/pages/ProductPage.tsx
@@ -4,7 +4,7 @@ import { GlobalContext } from '../context/GlobalContext';
 import SingleProductCard from '../components/SingleProductCard';
 
 const ProductPage = () => {
-  const { product, getSingleProduct } = useContext(GlobalContext);
+  const { product, getSingleProduct,roundDecimalsValues } = useContext(GlobalContext);
   const { productId } = useParams<{ productId: string }>();
 
   useEffect(() => {
@@ -22,7 +22,7 @@ const ProductPage = () => {
   }
   return (
     <div>
-      <SingleProductCard product ={product}/>
+      <SingleProductCard  roundDecimalsValues= {roundDecimalsValues} product ={product}/>
     </div>
   );
 };

--- a/src/pages/ProductPage.tsx
+++ b/src/pages/ProductPage.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { GlobalContext } from '../context/GlobalContext';
+import SingleProductCard from '../components/SingleProductCard';
 
 const ProductPage = () => {
   const { product, getSingleProduct } = useContext(GlobalContext);
@@ -20,83 +21,8 @@ const ProductPage = () => {
     );
   }
   return (
-    <div id='product'>
-      {/* Breadcrumb */}
-      <div className='row my-3'>
-        <div className='col'>
-          <div className='page-breadcrumb'>
-            <h4>
-              <span>
-                <Link to='/'>Home</Link>
-              </span>
-              {' > '}
-              <span>
-                <Link to={`/products/${product.id}`}>{product.title}</Link>
-              </span>
-            </h4>
-          </div>
-        </div>
-      </div>
-
-      {/* Product Card */}
-      <div className='row'>
-        <div className='col-sm-12 col-md-8 offset-md-2'>
-          <div className='card'>
-            <div className='row'>
-              {/* Product Img */}
-              <div className='col-sm-12 col-md-4'>
-                <div className='prod-img-container p-3'>
-                  <div
-                    className='prod-img'
-                    style={{ backgroundImage: `url(${product.image})` }}></div>
-                </div>
-              </div>
-              {/* product details */}
-              <div className='col-sm-12 col-md-8'>
-                <div className='card-body d-flex flex-column justify-content-between h-100'>
-                  {/* product title */}
-                  <h3 className='card-title'>
-                    {product.title}
-                    <div className=''>
-                      <small className='text-info'>${product.price}</small>
-                    </div>
-                  </h3>
-                  {/* product details */}
-                  <div className='card-details'>
-                    <h4>Description</h4>
-                    <p>{product.description}</p>
-                    <div>
-                      <span className='badge badge-warning'>
-                        {product.category}
-                      </span>
-                    </div>
-                  </div>
-                  {/* product add to cart */}
-                  <div className='card-cart'>
-                    <div className='row'>
-                      <div className='col-2'>
-                        <div className='form-group'>
-                          <select className='form-control'>
-                            <option value='1'>1</option>
-                            <option value='2'>2</option>
-                            <option value='3'>3</option>
-                          </select>
-                        </div>
-                      </div>
-
-                      <div className='col-10'>
-                        <button className='btn btn-block btn-danger'>
-                          Add To Cart
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+    <div>
+      <SingleProductCard product ={product}/>
     </div>
   );
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -25,5 +25,5 @@ type InitialStateType = {
     product: Product | undefined;
     getProducts: () => void;
     getSingleProduct: (productId:number) => void;
-    addDecimalValues: (priceTagNumber: number) => void;
+    roundDecimalsValues: (priceTagNumber: number) => void;
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -25,4 +25,5 @@ type InitialStateType = {
     product: Product | undefined;
     getProducts: () => void;
     getSingleProduct: (productId:number) => void;
+    addDecimalValues: (priceTagNumber: number) => void;
 };


### PR DESCRIPTION
**When you open your pull requests, remove the lines that start and end with underscores (\_)**

## Changes
1. Created helper function to round the price tag numbers in the context api 
2. passed the function down to children components 

## Purpose

- The price shown on the cards was showing either one decimal value or no decimal value at all. So I created the helper function, "roundDecimalValues" to round the decimal price by 2 using toFixed number method. 


### Closes #21 
